### PR TITLE
Fix KCTI_DESK-3 (set db connection name)

### DIFF
--- a/src/nrdbhandler.h
+++ b/src/nrdbhandler.h
@@ -49,6 +49,8 @@ public:
     {
 
     }
+
+    void setDbConnectionName(QString connName) {dbConnectionName = connName;}
 };
 
 


### PR DESCRIPTION
Added method in order to set a name for differentiate db connection