### PR TITLE
Introduce a flag that keeps the outcome (just if failed or not) of the last query

### DIFF
--- a/src/nrdbhandler.cpp
+++ b/src/nrdbhandler.cpp
@@ -24,6 +24,7 @@
 NrBaseDbHandler::NrBaseDbHandler(const DbhConfig &i_dbconf, QObject *parent)
     : QObject(parent)
     , m_DbConf(i_dbconf)
+    , m_lastQueryFailed(false)
 {
 
     UniqLogger *ul = UniqLogger::instance(m_DbConf.logId);
@@ -112,7 +113,7 @@ NrBaseDbHandler::prepareQuery(QSqlQuery &query, const QString &sql)
     if(!ok) {
         *m_logger << UNQL::LOG_CRITICAL << "PREPARE QUERY ERROR - got error: " << query.lastError().text() << " for query (" << query.lastQuery() << ")" << UNQL::eom;
     }
-
+    m_lastQueryFailed = !ok;
     return ok;
 }
 
@@ -127,7 +128,7 @@ NrBaseDbHandler::executeQuery(QSqlQuery &query)
     if(!ok) {        
         *m_logger << UNQL::LOG_CRITICAL << "EXECUTE QUERY ERROR - got error: " << query.lastError().text() << " for query (" << query.lastQuery() << ")" << UNQL::eom;
     }
-
+    m_lastQueryFailed = !ok;
     return ok;
 }
 

--- a/src/nrdbhandler.h
+++ b/src/nrdbhandler.h
@@ -76,6 +76,7 @@ protected:
     DbhConfig m_DbConf;
     QSqlDatabase _M_db;
     Logger *m_logger;
+    bool m_lastQueryFailed;
 
 protected:
     bool openDbConn();
@@ -103,6 +104,7 @@ public:
     inline const QString& dbTimezone() const { return m_DbConf.dbTimeZone; }
     inline const QString& connectionName() const { return m_DbConf.dbConnectionName; }
     inline int dbPort() const { return m_DbConf.dbPort; }
+    inline bool lastQueryFailed() const { return m_lastQueryFailed; }
 };
 
 #endif // DBHANDLER_H


### PR DESCRIPTION
It may be useful in the following case: consider a class MyDbHandler that extends publicly NrDbHandler class; MyDbHandler exposes a function

MyDataClass MyDbHandler::getMyData()
{
    MyDataClass ret;
    //...
    if (!executeQuery(query))
    {
        logError();
    }
    else
    {
        fillWithData(ret);
    }
    return ret;
}

At this point, a user of class MyDbHandler can make the following check:

{
    MyDataClass data = myDbHandler->getMyData();
    if (data.isEmpty())
    {
        if (myDbHandler->lastQueryFailed())
        {
            // data is empty because query has failed
        }
        else
        {
            // data is empty because that is the correct outcome of the query
        }
    }
}