### PR TITLE
Keep trace of last Db operation success/failure (last Db open, last query prepare/exec, last commit)

### DIFF
--- a/src/nrdbhandler.h
+++ b/src/nrdbhandler.h
@@ -72,10 +72,26 @@ class NrBaseDbHandler : public QObject
 {
     Q_OBJECT
 
+public:
+    enum ErrorType
+    {
+        ERROR_NONE = 0,
+        ERROR_OPEN,
+        ERROR_COMMIT,
+        ERROR_QUERY_PREPARE,
+        ERROR_QUERY_EXEC
+    };
+
+private:
+    void setError(ErrorType errorType, const QString &errorString);
+    void resetError();
+
 protected:
     DbhConfig m_DbConf;
     QSqlDatabase _M_db;
     Logger *m_logger;
+    QString m_errorString;
+    ErrorType m_errorType;
 
 protected:
     bool openDbConn();
@@ -103,6 +119,9 @@ public:
     inline const QString& dbTimezone() const { return m_DbConf.dbTimeZone; }
     inline const QString& connectionName() const { return m_DbConf.dbConnectionName; }
     inline int dbPort() const { return m_DbConf.dbPort; }
+    inline bool hasError() const { return m_errorType != ERROR_NONE; }
+    inline ErrorType getErrorType() const { return m_errorType; }
+    inline QString getErrorString() const { return m_errorString; }
 };
 
 #endif // DBHANDLER_H


### PR DESCRIPTION
They are only useful in case this class is publicly extended by a custom Db handler class that manages Db operations internally, without exposing them to users. An example: MyDbHandler extends publicly NrBaseDbHandler and exposes a function like this:

```
MyDataType MyDbHandler::getMyData()
{
   MyDataType ret;
   //...
   if (executeQuery(sqlQuery))
   {
      fillWithData(ret);
   }
   else
   {
      logError();
   }
   return ret;
}
```

A class that uses MyDbHandler can determine whether the result of getMyData() is empty because of an error or because that is the correct outcome of the query:
```
MyDataType data = m_dbHandler->getMyData();
if (data.isEmpty())
{
   if (m_dbHandler->lastDbOperationFailed())
   {
      // an error occurred (reported in logs)
   }
   else
   {
      // the outcome is useful even if empty
   }
}
```